### PR TITLE
update HPA manifests to autoscaling/v2 and fix deprecated APIs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
                         sh 'cp -R helm/* .'
 		        sh 'ls -ltr'
                         sh 'pwd'
-                        sh '/usr/local/bin/helm upgrade --install petclinic-app petclinic  --set image.repository=registry.hub.docker.com/prawinkorvi/petclinic --set image.tag=2'
+                        sh '/usr/local/bin/helm upgrade --install petclinic-app petclinic  --set image.repository=registry.hub.docker.com/skj800/puppet-clinic --set image.tag=2'
               			
             }           
         }

--- a/helm/petclinic/templates/petclinic-hpa.yml
+++ b/helm/petclinic/templates/petclinic-hpa.yml
@@ -1,12 +1,18 @@
- apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
- name: petclicnic-hpa
+  name: petclinic-hpa
 spec:
- maxReplicas: 5
- minReplicas: 1
- scaleTargetRef:
-   apiVersion: apps/v1
-   kind: Deployment
-   name: petclinic-deployment
- targetCPUUtilizationPercentage: 50
+  maxReplicas: 5
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: petclinic-deployment
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/helm/petclinic/templates/petclinic-mem.yaml
+++ b/helm/petclinic/templates/petclinic-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: petclinic-mem-hpa

--- a/helm/petclinic/templates/petclinic-mem.yaml
+++ b/helm/petclinic/templates/petclinic-mem.yaml
@@ -13,4 +13,6 @@ spec:
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: 50
+      target:
+        type: Utilization
+        averageUtilization: 50


### PR DESCRIPTION
- Replaced deprecated autoscaling/v2beta1
- Updated HPA manifests to autoscaling/v2
- Fixed CPU metrics syntax
- Corrected metadata name typo
- Ensured compatibility with Kubernetes 1.25+